### PR TITLE
ラジオボタンの状態によりtodoの表示を切り替える機能の追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,10 +12,10 @@
     <div>
       <h1>TODO-APP</h1>
     </div>
-    <div>
-        <input type="radio" name="state" checked>すべて
-        <input type="radio" name="state">作業中
-        <input type="radio" name="state">完了
+    <div id="radio-form-section">
+        <input type="radio" name="state" id="all-state" value="all" checked>すべて
+        <input type="radio" name="state" id="work-state" value="work">作業中
+        <input type="radio" name="state" id="comp-state" value="comp">完了
     </div>
     <div>
       <h2>todoを追加</h2>

--- a/main.js
+++ b/main.js
@@ -5,9 +5,15 @@
   const tableBody = document.getElementById('table-body');
   const formSectionInput = document.getElementById('form-section_input');
   const addBtn = document.getElementById('add-btn');
+  const radioFormSection = document.getElementById('radio-form-section');
+  // 状態ボタンをクリックした時の挙動
   addBtn.addEventListener('click', () => {
     addTodo();
   })
+  // ラジオボタンをクリックが切り替わった時の挙動
+  radioFormSection.addEventListener('change', (event) => {
+    changeTodoDisplay(event.target.value);
+  });
   // inputに入力された内容のtodoを追加する
   const addTodo = () => {
     const content = formSectionInput.value;
@@ -25,23 +31,29 @@
       deleteBtn
     }
     todos.push(todo);
-    showTodos()
+    // idを振る
+    todos.forEach((todo, index) => todo.id = index + 1);
+    // ラジオボタンの状態と状態切り替えボタンが一致するtodoを表示
+    for(let i = 0; i < radioFormSection.children.length; i++) {
+      if(radioFormSection.children[i].checked === true) {
+        changeTodoDisplay(radioFormSection.children[i].value);
+      }
+    }
     formSectionInput.value = '';
   }
 
   // 追加されたtodoを表示する
-  const showTodos = () => {
+  const showTodos = (todos) => {
     // テーブルの中身をリセット
     while(tableBody.firstChild) {
       tableBody.textContent = '';
     }
-    todos.forEach((todo, index) => {
+    todos.forEach((todo) => {
       const tr = document.createElement('tr');
       const id = document.createElement('td');
       const content = document.createElement('td');
       const state = document.createElement('td');
       const remove = document.createElement('td');
-      todo.id = index + 1;
       id.textContent = todo.id
       content.textContent = todo.content;
       tableBody.appendChild(tr);
@@ -52,7 +64,6 @@
       state.appendChild(todo.stateBtn);
       remove.appendChild(todo.deleteBtn);
     });
-    console.log(todos);
   };
   // 状態ボタン「作業中⇄完了」の切り替え
   const switchState = (stateBtn) => {
@@ -60,6 +71,26 @@
       stateBtn.textContent = '完了';
     } else {
       stateBtn.textContent = '作業中';
+    };
+    // ラジオボタンの状態と状態切り替えボタンが一致するtodoを表示
+    for(let i = 0; i < radioFormSection.children.length; i++) {
+      if(radioFormSection.children[i].checked === true) {
+        changeTodoDisplay(radioFormSection.children[i].value);
+      };
+    };
+  };
+  // ラジオボタンでtodo表示の切り替え
+  const changeTodoDisplay = (radioBtnState) => {
+    if(radioBtnState === 'all') {
+      showTodos(todos);
+    };
+    if(radioBtnState === 'work') {
+      const filterTodos = todos.filter((todo) => todo.stateBtn.textContent === '作業中');
+      showTodos(filterTodos);
+    };
+    if(radioBtnState === 'comp') {
+      const filterTodos = todos.filter((todo) => todo.stateBtn.textContent === '完了');
+      showTodos(filterTodos);
     };
   };
 }());


### PR DESCRIPTION
ラジオボタンの状態と状態切り替えボタンが一致するtodoを表示する
・ラジオボタンを切り替えた時、状態切り替えボタンと同じtodoを表示する。
・状態切り替えボタンを押した時、ラジオボタンの状態と同じtodoを表示する。